### PR TITLE
Setup CI with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,166 @@
+sudo: true
+language: cpp
+
+os: linux
+dist: trusty
+
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/deps/cmake
+
+matrix:
+  include:
+    ##======================
+    ## Linux
+    ##======================
+
+    ##===============
+    ## GCC
+    ##===============
+    - env: BUILD_TYPE=Debug COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7
+      addons: &gcc7
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - g++-7
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7
+      addons: *gcc7
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6
+      addons: &gcc6
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6
+      addons: *gcc6
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5
+      addons: &gcc5
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5
+      addons: *gcc5
+
+    ##===============
+    ## Clang
+    ##===============
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-5.0 CC=clang-5.0
+      addons: &clang50
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-5.0
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-5.0 CC=clang-5.0
+      addons: *clang50
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-4.0 CC=clang-4.0
+      addons: &clang40
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-4.0
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-4.0 CC=clang-4.0
+      addons: *clang40
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-3.9 CC=clang-3.9
+      addons: &clang39
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.9
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-3.9 CC=clang-3.9
+      addons: *clang39
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-3.8 CC=clang-3.8
+      addons: &clang38
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.8
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-3.8 CC=clang-3.8
+      addons: *clang38
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-3.7 CC=clang-3.7
+      addons: &clang37
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-3.7 CC=clang-3.7
+      addons: *clang37
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-3.6 CC=clang-3.6
+      addons: &clang36
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.6
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-3.6 CC=clang-3.6
+      addons: *clang36
+
+    - env: BUILD_TYPE=Debug COMPILER_NAME=clang CXX=clang++-3.5 CC=clang-3.5
+      addons: &clang35
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.5
+
+    - env: BUILD_TYPE=Release COMPILER_NAME=clang CXX=clang++-3.5 CC=clang-3.5
+      addons: *clang35
+
+install:
+  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+  - sudo apt-get install libboost-all-dev
+  - mkdir -pv "${DEPS_DIR}" && cd "${DEPS_DIR}"
+
+  ## Update the ancient version of CMake installed on Travis...
+  ## Version 3,5 has been chosen since it is the version that ships with
+  ## Ubuntu 16.04 LTS and could, therefore, be considered te minimum supported
+  ## version of CMake.
+  - |
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+        CMAKE_URL="https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz"
+        mkdir -p cmake
+        travis_retry wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar -xz --strip-components=1 -C cmake
+        export PATH="${DEPS_DIR}/cmake/bin:${PATH}"
+      fi
+      cd "${TRAVIS_BUILD_DIR}"
+  - cmake --version
+
+before_script:
+  - mkdir -p build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDLIBXX_ENABLE_TESTS=ON ..
+
+script:
+  - make -j2
+  - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: true
-language: cpp
+language: generic
 
 os: linux
 dist: trusty
@@ -7,6 +7,7 @@ dist: trusty
 cache:
   directories:
     - ${TRAVIS_BUILD_DIR}/deps/cmake
+    - ${TRAVIS_BUILD_DIR}/deps/boost
 
 matrix:
   include:
@@ -139,7 +140,6 @@ matrix:
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - sudo apt-get install libboost-all-dev
   - mkdir -pv "${DEPS_DIR}" && cd "${DEPS_DIR}"
 
   ## Update the ancient version of CMake installed on Travis...
@@ -153,14 +153,27 @@ install:
         travis_retry wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar -xz --strip-components=1 -C cmake
         export PATH="${DEPS_DIR}/cmake/bin:${PATH}"
       fi
-      cd "${TRAVIS_BUILD_DIR}"
   - cmake --version
+
+  ## Travis also has an older version of Boost (1.55.0) that does not contain
+  ## boost::optional::value. This came about in 1.56.0... We grab a copy of
+  ## version 1.58.0 which is what ships with Ubuntu 16.04 LTS and could, therefore
+  ## be considered the minimum supported version of Boost.
+  - |
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+        BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz"
+        mkdir -p boost/boost_1_58_0
+        travis_retry wget -O - "${BOOST_URL}" | tar -xz --strip-components=1 -C boost/boost_1_58_0
+        export BOOST_ROOT="${DEPS_DIR}/boost/boost_1_58_0"
+      fi
+  - cd "${TRAVIS_BUILD_DIR}"
+  - echo "${BOOST_ROOT}"
 
 before_script:
   - mkdir -p build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDLIBXX_ENABLE_TESTS=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDLIBXX_ENABLE_TESTS=ON -DBOOST_ROOT="${BOOST_ROOT}" ..
 
 script:
-  - make -j2
+  - cmake --build .
   - ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ option(DLIBXX_ENABLE_TESTS OFF "Enable testing")
 include_directories(include)
 
 # =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+### Find dependencies
+## We require version 1.58.0 or later for the `value` function in
+## `boost::optional` that allows us to interchange with `std::optional`
+find_package (Boost 1.58.0 REQUIRED)
+include_directories (${Boost_INCLUDE_DIRS})
+
+# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 ### Build libdlibxx
 add_library(
   dlibxx SHARED

--- a/test/test_symbol_loading.cpp
+++ b/test/test_symbol_loading.cpp
@@ -49,7 +49,7 @@ TEST_F(TestLoadSymbol, Lookup_WhenOptionalIsValid_FunctionWillBeCallable) {
 
   auto function = lib.lookup<void(int, char)>("load_me");
 
-  EXPECT_NO_THROW(function.get()(int{}, char{}));
+  EXPECT_NO_THROW(function.value()(int{}, char{}));
 }
 
 TEST_F(TestLoadSymbol, Lookup_WhenSymbolNotFound_WillReturnEmptyOptional) {
@@ -60,7 +60,7 @@ TEST_F(TestLoadSymbol, Lookup_WhenSymbolNotFound_WillReturnEmptyOptional) {
 
   auto function = lib.lookup<void(int, char)>("load_me");
 
-  EXPECT_THROW(function.get()(int{}, char{}), std::bad_function_call);
+  EXPECT_THROW(function.value()(int{}, char{}), std::bad_function_call);
 }
 
 class TestFunctionPtrCast : public Test {};

--- a/test/test_symbol_loading.cpp
+++ b/test/test_symbol_loading.cpp
@@ -49,7 +49,7 @@ TEST_F(TestLoadSymbol, Lookup_WhenOptionalIsValid_FunctionWillBeCallable) {
 
   auto function = lib.lookup<void(int, char)>("load_me");
 
-  EXPECT_NO_THROW(function.value()(int{}, char{}));
+  EXPECT_NO_THROW(function.get()(int{}, char{}));
 }
 
 TEST_F(TestLoadSymbol, Lookup_WhenSymbolNotFound_WillReturnEmptyOptional) {
@@ -60,7 +60,7 @@ TEST_F(TestLoadSymbol, Lookup_WhenSymbolNotFound_WillReturnEmptyOptional) {
 
   auto function = lib.lookup<void(int, char)>("load_me");
 
-  EXPECT_THROW(function.value()(int{}, char{}), std::bad_function_call);
+  EXPECT_THROW(function.get()(int{}, char{}), std::bad_function_call);
 }
 
 class TestFunctionPtrCast : public Test {};


### PR DESCRIPTION
Run building and testing on a matrix of compilers and configurations:

g++ versions 5, 6, and 7
clang++ versions 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, and 5.0
Debug and Release configurations

Note that CMake and Boost on Travis are slightly older than we require and so these are fetched
and cached between builds.

Issue: #5 